### PR TITLE
Add GitHub CI workflow for build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Build
+      run: npm run build
+    
+    - name: Lint
+      run: npm run lint
+    
+    - name: Run tests
+      run: npm run test:run


### PR DESCRIPTION
This PR adds GitHub Actions CI workflow that:

1. Builds the repository
2. Runs linting
3. Runs the tests

The workflow is triggered on push to main branch and on pull requests targeting the main branch.

Fixes #4

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3421020889924503bdf43e50b9b7ebe1)