### PR TITLE
Implement pull request service

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -35,8 +35,106 @@
 
 .card {
   padding: 2em;
+  margin-bottom: 2em;
+  border: 1px solid #eaeaea;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+}
+
+.counter-card {
+  margin-top: 2em;
 }
 
 .read-the-docs {
   color: #888;
+}
+
+/* Form styles */
+.form-group {
+  margin-bottom: 1em;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.form-group label {
+  margin-bottom: 0.5em;
+  font-weight: bold;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  background-color: #646cff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.25s;
+}
+
+button:hover {
+  background-color: #535bf2;
+}
+
+/* Pull Request Monitor styles */
+.pull-request-monitor {
+  text-align: left;
+  padding: 1em;
+}
+
+.monitor-section {
+  margin-bottom: 2em;
+}
+
+.monitor-section h3 {
+  border-bottom: 1px solid #eaeaea;
+  padding-bottom: 0.5em;
+  margin-bottom: 1em;
+}
+
+.pr-list {
+  list-style-type: none;
+  padding: 0;
+}
+
+.pr-item {
+  padding: 0.8em;
+  margin-bottom: 0.5em;
+  border: 1px solid #eaeaea;
+  border-radius: 4px;
+  background-color: #f9f9f9;
+}
+
+.pr-item a {
+  color: #646cff;
+  text-decoration: none;
+}
+
+.pr-item a:hover {
+  text-decoration: underline;
+}
+
+.error {
+  color: #ff4d4f;
+  padding: 1em;
+  border: 1px solid #ff4d4f;
+  border-radius: 4px;
+  background-color: #fff1f0;
+}
+
+.monitor-container {
+  border: 1px solid #eaeaea;
+  border-radius: 8px;
+  padding: 1em;
+  background-color: white;
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,11 +1,16 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import App from './App'
 
+// Mock the PullRequestMonitor component
+vi.mock('./components/PullRequestMonitor', () => ({
+  default: vi.fn(() => <div data-testid="mock-pr-monitor">Mock PR Monitor</div>)
+}))
+
 describe('App', () => {
-  it('renders Vite + React heading', () => {
+  it('renders GitHub Repository Monitor heading', () => {
     render(<App />)
-    expect(screen.getByText('Vite + React')).toBeInTheDocument()
+    expect(screen.getByText('GitHub Repository Monitor')).toBeInTheDocument()
   })
 
   it('renders count button with initial value', () => {
@@ -30,10 +35,30 @@ describe('App', () => {
     expect(screen.getByAltText('React logo')).toBeInTheDocument()
   })
 
-  it('renders edit instruction text', () => {
+  it('renders repository form fields', () => {
     render(<App />)
-    expect(screen.getByText((_, element) => {
-      return element?.textContent === 'Edit src/App.tsx and save to test HMR'
-    })).toBeInTheDocument()
+    expect(screen.getByLabelText('Repository Owner:')).toBeInTheDocument()
+    expect(screen.getByLabelText('Repository Name:')).toBeInTheDocument()
+    expect(screen.getByLabelText('GitHub Token (optional):')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Monitor Repository' })).toBeInTheDocument()
+  })
+
+  it('updates repository when form is submitted', () => {
+    render(<App />)
+    
+    // Get form elements
+    const ownerInput = screen.getByLabelText('Repository Owner:')
+    const nameInput = screen.getByLabelText('Repository Name:')
+    const submitButton = screen.getByRole('button', { name: 'Monitor Repository' })
+    
+    // Change input values
+    fireEvent.change(ownerInput, { target: { value: 'testuser' } })
+    fireEvent.change(nameInput, { target: { value: 'test-repo' } })
+    
+    // Submit the form
+    fireEvent.click(submitButton)
+    
+    // Verify the PullRequestMonitor component is rendered
+    expect(screen.getByTestId('mock-pr-monitor')).toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 import PullRequestMonitor from './components/PullRequestMonitor'
-import { Repository } from './services/PullRequestService'
+import type { Repository } from './services/PullRequestService'
 
 function App() {
   const [count, setCount] = useState(0)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,20 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import PullRequestMonitor from './components/PullRequestMonitor'
+import { Repository } from './services/PullRequestService'
 
 function App() {
   const [count, setCount] = useState(0)
+  const [repository, setRepository] = useState<Repository>({ owner: 'neubig', name: 'repo-monitor' })
+  const [owner, setOwner] = useState('neubig')
+  const [name, setName] = useState('repo-monitor')
+  const [token, setToken] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setRepository({ owner, name })
+  }
 
   return (
     <>
@@ -16,15 +27,57 @@ function App() {
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
-      <h1>Vite + React</h1>
+      <h1>GitHub Repository Monitor</h1>
+      
       <div className="card">
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="owner">Repository Owner:</label>
+            <input 
+              type="text" 
+              id="owner" 
+              value={owner} 
+              onChange={(e) => setOwner(e.target.value)}
+              required
+            />
+          </div>
+          
+          <div className="form-group">
+            <label htmlFor="name">Repository Name:</label>
+            <input 
+              type="text" 
+              id="name" 
+              value={name} 
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+          
+          <div className="form-group">
+            <label htmlFor="token">GitHub Token (optional):</label>
+            <input 
+              type="password" 
+              id="token" 
+              value={token} 
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="For private repositories"
+            />
+          </div>
+          
+          <button type="submit">Monitor Repository</button>
+        </form>
+      </div>
+      
+      <div className="monitor-container">
+        <PullRequestMonitor repository={repository} githubToken={token || undefined} />
+      </div>
+      
+      <div className="card counter-card">
         <button onClick={() => setCount((count) => count + 1)}>
           count is {count}
         </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
       </div>
+      
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>

--- a/src/components/PullRequestMonitor.test.tsx
+++ b/src/components/PullRequestMonitor.test.tsx
@@ -17,7 +17,10 @@ vi.mock('../services/PullRequestService', () => {
 
 describe('PullRequestMonitor', () => {
   const mockRepository = { owner: 'testowner', name: 'testrepo' };
-  let mockService: any;
+  let mockService: {
+    getPullRequestsWithNoReviewers: ReturnType<typeof vi.fn>;
+    getReviewedNonDraftPullRequests: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     // Reset mocks before each test
@@ -29,7 +32,9 @@ describe('PullRequestMonitor', () => {
       getReviewedNonDraftPullRequests: vi.fn(),
     };
 
-    (PullRequestService as any).mockImplementation(() => mockService);
+    (PullRequestService as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => mockService
+    );
   });
 
   it('should display loading state initially', () => {

--- a/src/components/PullRequestMonitor.test.tsx
+++ b/src/components/PullRequestMonitor.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import PullRequestMonitor from './PullRequestMonitor';
+import PullRequestService from '../services/PullRequestService';
+
+// Mock the PullRequestService
+vi.mock('../services/PullRequestService', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      getPullRequestsWithNoReviewers: vi.fn(),
+      getReviewedNonDraftPullRequests: vi.fn()
+    })),
+    // Export the interface types
+    __esModule: true
+  };
+});
+
+describe('PullRequestMonitor', () => {
+  const mockRepository = { owner: 'testowner', name: 'testrepo' };
+  let mockService: any;
+  
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.resetAllMocks();
+    
+    // Setup the mock service instance
+    mockService = {
+      getPullRequestsWithNoReviewers: vi.fn(),
+      getReviewedNonDraftPullRequests: vi.fn()
+    };
+    
+    (PullRequestService as any).mockImplementation(() => mockService);
+  });
+  
+  it('should display loading state initially', () => {
+    // Setup mock to return a promise that doesn't resolve immediately
+    mockService.getPullRequestsWithNoReviewers.mockReturnValue(new Promise(() => {}));
+    mockService.getReviewedNonDraftPullRequests.mockReturnValue(new Promise(() => {}));
+    
+    render(<PullRequestMonitor repository={mockRepository} />);
+    
+    expect(screen.getByText('Loading pull request data...')).toBeInTheDocument();
+  });
+  
+  it('should display error message when API call fails', async () => {
+    // Setup mock to reject with an error
+    const errorMessage = 'API error occurred';
+    mockService.getPullRequestsWithNoReviewers.mockRejectedValue(new Error(errorMessage));
+    mockService.getReviewedNonDraftPullRequests.mockRejectedValue(new Error(errorMessage));
+    
+    render(<PullRequestMonitor repository={mockRepository} />);
+    
+    await waitFor(() => {
+      expect(screen.getByText(`Error: ${errorMessage}`)).toBeInTheDocument();
+    });
+  });
+  
+  it('should display pull requests with no reviewers', async () => {
+    // Mock data
+    const mockPRs = [
+      { id: 1, number: 101, title: 'PR 1', url: 'https://github.com/test/pr/101', isDraft: false, hasReviewers: false, hasBeenReviewed: false },
+      { id: 2, number: 102, title: 'PR 2', url: 'https://github.com/test/pr/102', isDraft: false, hasReviewers: false, hasBeenReviewed: false }
+    ];
+    
+    // Setup mocks to resolve with data
+    mockService.getPullRequestsWithNoReviewers.mockResolvedValue(mockPRs);
+    mockService.getReviewedNonDraftPullRequests.mockResolvedValue([]);
+    
+    render(<PullRequestMonitor repository={mockRepository} />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Pull Request Monitor for testowner/testrepo')).toBeInTheDocument();
+      expect(screen.getByText('Open PRs with No Reviewers')).toBeInTheDocument();
+      expect(screen.getByText('#101: PR 1')).toBeInTheDocument();
+      expect(screen.getByText('#102: PR 2')).toBeInTheDocument();
+      expect(screen.getByText('No pull requests found in this category.')).toBeInTheDocument(); // For reviewed PRs
+    });
+  });
+  
+  it('should display reviewed non-draft pull requests', async () => {
+    // Mock data
+    const mockReviewedPRs = [
+      { id: 3, number: 103, title: 'Reviewed PR', url: 'https://github.com/test/pr/103', isDraft: false, hasReviewers: true, hasBeenReviewed: true }
+    ];
+    
+    // Setup mocks to resolve with data
+    mockService.getPullRequestsWithNoReviewers.mockResolvedValue([]);
+    mockService.getReviewedNonDraftPullRequests.mockResolvedValue(mockReviewedPRs);
+    
+    render(<PullRequestMonitor repository={mockRepository} />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Pull Request Monitor for testowner/testrepo')).toBeInTheDocument();
+      expect(screen.getByText('Reviewed Non-Draft PRs')).toBeInTheDocument();
+      expect(screen.getByText('#103: Reviewed PR')).toBeInTheDocument();
+      expect(screen.getByText('No pull requests found in this category.')).toBeInTheDocument(); // For PRs with no reviewers
+    });
+  });
+  
+  it('should pass the GitHub token to the service when provided', async () => {
+    // Setup mocks to resolve with empty arrays
+    mockService.getPullRequestsWithNoReviewers.mockResolvedValue([]);
+    mockService.getReviewedNonDraftPullRequests.mockResolvedValue([]);
+    
+    const token = 'test-github-token';
+    render(<PullRequestMonitor repository={mockRepository} githubToken={token} />);
+    
+    await waitFor(() => {
+      expect(mockService.getPullRequestsWithNoReviewers).toHaveBeenCalledWith(mockRepository, token);
+      expect(mockService.getReviewedNonDraftPullRequests).toHaveBeenCalledWith(mockRepository, token);
+    });
+  });
+});

--- a/src/components/PullRequestMonitor.tsx
+++ b/src/components/PullRequestMonitor.tsx
@@ -13,13 +13,13 @@ export function PullRequestMonitor({ repository, githubToken }: PullRequestMonit
   const [pullRequestsWithNoReviewers, setPullRequestsWithNoReviewers] = useState<PullRequest[]>([]);
   const [reviewedPullRequests, setReviewedPullRequests] = useState<PullRequest[]>([]);
 
-  const service = new PullRequestService();
-
   useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
         setError(null);
+
+        const service = new PullRequestService();
 
         // Fetch both types of pull requests
         const [noReviewers, reviewed] = await Promise.all([

--- a/src/components/PullRequestMonitor.tsx
+++ b/src/components/PullRequestMonitor.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import PullRequestService, { PullRequest, Repository } from '../services/PullRequestService';
+
+interface PullRequestMonitorProps {
+  repository: Repository;
+  githubToken?: string;
+}
+
+export function PullRequestMonitor({ repository, githubToken }: PullRequestMonitorProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pullRequestsWithNoReviewers, setPullRequestsWithNoReviewers] = useState<PullRequest[]>([]);
+  const [reviewedPullRequests, setReviewedPullRequests] = useState<PullRequest[]>([]);
+  
+  const service = new PullRequestService();
+  
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        
+        // Fetch both types of pull requests
+        const [noReviewers, reviewed] = await Promise.all([
+          service.getPullRequestsWithNoReviewers(repository, githubToken),
+          service.getReviewedNonDraftPullRequests(repository, githubToken)
+        ]);
+        
+        setPullRequestsWithNoReviewers(noReviewers);
+        setReviewedPullRequests(reviewed);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An unknown error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+    
+    fetchData();
+  }, [repository, githubToken]);
+  
+  if (loading) {
+    return <div>Loading pull request data...</div>;
+  }
+  
+  if (error) {
+    return <div className="error">Error: {error}</div>;
+  }
+  
+  return (
+    <div className="pull-request-monitor">
+      <h2>Pull Request Monitor for {repository.owner}/{repository.name}</h2>
+      
+      <div className="monitor-section">
+        <h3>Open PRs with No Reviewers</h3>
+        {pullRequestsWithNoReviewers.length === 0 ? (
+          <p>No pull requests found in this category.</p>
+        ) : (
+          <ul className="pr-list">
+            {pullRequestsWithNoReviewers.map(pr => (
+              <li key={pr.id} className="pr-item">
+                <a href={pr.url} target="_blank" rel="noopener noreferrer">
+                  #{pr.number}: {pr.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      
+      <div className="monitor-section">
+        <h3>Reviewed Non-Draft PRs</h3>
+        {reviewedPullRequests.length === 0 ? (
+          <p>No pull requests found in this category.</p>
+        ) : (
+          <ul className="pr-list">
+            {reviewedPullRequests.map(pr => (
+              <li key={pr.id} className="pr-item">
+                <a href={pr.url} target="_blank" rel="noopener noreferrer">
+                  #{pr.number}: {pr.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PullRequestMonitor;

--- a/src/components/PullRequestMonitor.tsx
+++ b/src/components/PullRequestMonitor.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import PullRequestService, { PullRequest, Repository } from '../services/PullRequestService';
+import PullRequestService from '../services/PullRequestService';
+import type { PullRequest, Repository } from '../services/PullRequestService';
 
 interface PullRequestMonitorProps {
   repository: Repository;

--- a/src/services/PullRequestService.test.ts
+++ b/src/services/PullRequestService.test.ts
@@ -3,7 +3,8 @@ import { PullRequestService } from './PullRequestService';
 import type { Repository } from './PullRequestService';
 
 // Mock the fetch function
-vi.stubGlobal('fetch', vi.fn());
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
 
 describe('PullRequestService', () => {
   let service: PullRequestService;
@@ -43,7 +44,7 @@ describe('PullRequestService', () => {
     ];
 
     // Setup mock fetch response
-    (fetch as any).mockResolvedValueOnce({
+    mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => mockPullRequests,
     });
@@ -81,7 +82,7 @@ describe('PullRequestService', () => {
 
   it('should handle API errors gracefully', async () => {
     // Setup mock fetch to return an error
-    (fetch as any).mockResolvedValueOnce({
+    mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
       statusText: 'Not Found',
@@ -129,7 +130,7 @@ describe('PullRequestService', () => {
     ];
 
     // Setup mock fetch response
-    (fetch as any).mockResolvedValueOnce({
+    mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => mockPullRequests,
     });
@@ -178,7 +179,7 @@ describe('PullRequestService', () => {
     ];
 
     // Setup mock fetch response
-    (fetch as any).mockResolvedValueOnce({
+    mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => mockPullRequests,
     });
@@ -193,7 +194,7 @@ describe('PullRequestService', () => {
 
   it('should use authentication token when provided', async () => {
     // Setup mock fetch response
-    (fetch as any).mockResolvedValueOnce({
+    mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => [],
     });

--- a/src/services/PullRequestService.test.ts
+++ b/src/services/PullRequestService.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PullRequestService, Repository, PullRequest } from './PullRequestService';
+
+// Mock the global fetch function
+global.fetch = vi.fn();
+
+describe('PullRequestService', () => {
+  let service: PullRequestService;
+  let mockRepo: Repository;
+  
+  beforeEach(() => {
+    service = new PullRequestService();
+    mockRepo = { owner: 'testowner', name: 'testrepo' };
+    
+    // Reset the mock before each test
+    vi.resetAllMocks();
+  });
+  
+  it('should fetch pull requests from GitHub API', async () => {
+    // Mock response data
+    const mockPullRequests = [
+      {
+        id: 1,
+        number: 101,
+        title: 'Test PR 1',
+        html_url: 'https://github.com/testowner/testrepo/pull/101',
+        draft: false,
+        requested_reviewers: [],
+        review_comments: 0,
+        reviews_count: 0
+      },
+      {
+        id: 2,
+        number: 102,
+        title: 'Test PR 2',
+        html_url: 'https://github.com/testowner/testrepo/pull/102',
+        draft: true,
+        requested_reviewers: [{ login: 'reviewer1' }],
+        review_comments: 0,
+        reviews_count: 0
+      }
+    ];
+    
+    // Setup mock fetch response
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockPullRequests
+    });
+    
+    const result = await service.fetchPullRequests(mockRepo);
+    
+    // Verify fetch was called with correct URL
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/testowner/testrepo/pulls?state=open',
+      { headers: { 'Accept': 'application/vnd.github.v3+json' } }
+    );
+    
+    // Verify the result is transformed correctly
+    expect(result).toEqual([
+      {
+        id: 1,
+        number: 101,
+        title: 'Test PR 1',
+        url: 'https://github.com/testowner/testrepo/pull/101',
+        isDraft: false,
+        hasReviewers: false,
+        hasBeenReviewed: false
+      },
+      {
+        id: 2,
+        number: 102,
+        title: 'Test PR 2',
+        url: 'https://github.com/testowner/testrepo/pull/102',
+        isDraft: true,
+        hasReviewers: true,
+        hasBeenReviewed: false
+      }
+    ]);
+  });
+  
+  it('should handle API errors gracefully', async () => {
+    // Setup mock fetch to return an error
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found'
+    });
+    
+    // Verify that the service throws an error
+    await expect(service.fetchPullRequests(mockRepo)).rejects.toThrow('GitHub API error: 404 Not Found');
+  });
+  
+  it('should filter pull requests with no reviewers', async () => {
+    // Mock response data
+    const mockPullRequests = [
+      {
+        id: 1,
+        number: 101,
+        title: 'PR with no reviewers',
+        html_url: 'https://github.com/testowner/testrepo/pull/101',
+        draft: false,
+        requested_reviewers: [],
+        review_comments: 0,
+        reviews_count: 0
+      },
+      {
+        id: 2,
+        number: 102,
+        title: 'PR with reviewers',
+        html_url: 'https://github.com/testowner/testrepo/pull/102',
+        draft: false,
+        requested_reviewers: [{ login: 'reviewer1' }],
+        review_comments: 0,
+        reviews_count: 0
+      },
+      {
+        id: 3,
+        number: 103,
+        title: 'Draft PR with no reviewers',
+        html_url: 'https://github.com/testowner/testrepo/pull/103',
+        draft: true,
+        requested_reviewers: [],
+        review_comments: 0,
+        reviews_count: 0
+      }
+    ];
+    
+    // Setup mock fetch response
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockPullRequests
+    });
+    
+    const result = await service.getPullRequestsWithNoReviewers(mockRepo);
+    
+    // Verify only the non-draft PR with no reviewers is returned
+    expect(result.length).toBe(1);
+    expect(result[0].number).toBe(101);
+    expect(result[0].title).toBe('PR with no reviewers');
+  });
+  
+  it('should filter reviewed non-draft pull requests', async () => {
+    // Mock response data
+    const mockPullRequests = [
+      {
+        id: 1,
+        number: 101,
+        title: 'Reviewed non-draft PR',
+        html_url: 'https://github.com/testowner/testrepo/pull/101',
+        draft: false,
+        requested_reviewers: [],
+        review_comments: 5,
+        reviews_count: 1
+      },
+      {
+        id: 2,
+        number: 102,
+        title: 'Non-reviewed non-draft PR',
+        html_url: 'https://github.com/testowner/testrepo/pull/102',
+        draft: false,
+        requested_reviewers: [{ login: 'reviewer1' }],
+        review_comments: 0,
+        reviews_count: 0
+      },
+      {
+        id: 3,
+        number: 103,
+        title: 'Reviewed draft PR',
+        html_url: 'https://github.com/testowner/testrepo/pull/103',
+        draft: true,
+        requested_reviewers: [],
+        review_comments: 3,
+        reviews_count: 1
+      }
+    ];
+    
+    // Setup mock fetch response
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockPullRequests
+    });
+    
+    const result = await service.getReviewedNonDraftPullRequests(mockRepo);
+    
+    // Verify only the reviewed non-draft PR is returned
+    expect(result.length).toBe(1);
+    expect(result[0].number).toBe(101);
+    expect(result[0].title).toBe('Reviewed non-draft PR');
+  });
+  
+  it('should use authentication token when provided', async () => {
+    // Setup mock fetch response
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => []
+    });
+    
+    const token = 'test-token';
+    await service.fetchPullRequests(mockRepo, token);
+    
+    // Verify fetch was called with the authorization header
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/testowner/testrepo/pulls?state=open',
+      { 
+        headers: { 
+          'Accept': 'application/vnd.github.v3+json',
+          'Authorization': 'token test-token'
+        } 
+      }
+    );
+  });
+});

--- a/src/services/PullRequestService.test.ts
+++ b/src/services/PullRequestService.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { PullRequestService, Repository, PullRequest } from './PullRequestService';
+import { PullRequestService } from './PullRequestService';
+import type { Repository } from './PullRequestService';
 
-// Mock the global fetch function
-global.fetch = vi.fn();
+// Mock the fetch function
+vi.stubGlobal('fetch', vi.fn());
 
 describe('PullRequestService', () => {
   let service: PullRequestService;
@@ -42,7 +43,7 @@ describe('PullRequestService', () => {
     ];
     
     // Setup mock fetch response
-    (global.fetch as any).mockResolvedValueOnce({
+    (fetch as any).mockResolvedValueOnce({
       ok: true,
       json: async () => mockPullRequests
     });
@@ -50,7 +51,7 @@ describe('PullRequestService', () => {
     const result = await service.fetchPullRequests(mockRepo);
     
     // Verify fetch was called with correct URL
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.github.com/repos/testowner/testrepo/pulls?state=open',
       { headers: { 'Accept': 'application/vnd.github.v3+json' } }
     );
@@ -80,7 +81,7 @@ describe('PullRequestService', () => {
   
   it('should handle API errors gracefully', async () => {
     // Setup mock fetch to return an error
-    (global.fetch as any).mockResolvedValueOnce({
+    (fetch as any).mockResolvedValueOnce({
       ok: false,
       status: 404,
       statusText: 'Not Found'
@@ -126,7 +127,7 @@ describe('PullRequestService', () => {
     ];
     
     // Setup mock fetch response
-    (global.fetch as any).mockResolvedValueOnce({
+    (fetch as any).mockResolvedValueOnce({
       ok: true,
       json: async () => mockPullRequests
     });
@@ -175,7 +176,7 @@ describe('PullRequestService', () => {
     ];
     
     // Setup mock fetch response
-    (global.fetch as any).mockResolvedValueOnce({
+    (fetch as any).mockResolvedValueOnce({
       ok: true,
       json: async () => mockPullRequests
     });
@@ -190,7 +191,7 @@ describe('PullRequestService', () => {
   
   it('should use authentication token when provided', async () => {
     // Setup mock fetch response
-    (global.fetch as any).mockResolvedValueOnce({
+    (fetch as any).mockResolvedValueOnce({
       ok: true,
       json: async () => []
     });
@@ -199,7 +200,7 @@ describe('PullRequestService', () => {
     await service.fetchPullRequests(mockRepo, token);
     
     // Verify fetch was called with the authorization header
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.github.com/repos/testowner/testrepo/pulls?state=open',
       { 
         headers: { 

--- a/src/services/PullRequestService.ts
+++ b/src/services/PullRequestService.ts
@@ -18,6 +18,16 @@ export interface Repository {
   name: string;
 }
 
+interface GitHubPullRequest {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  draft: boolean;
+  requested_reviewers: unknown[];
+  reviews?: unknown[];
+}
+
 export class PullRequestService {
   private baseUrl = 'https://api.github.com';
 
@@ -47,7 +57,7 @@ export class PullRequestService {
       const data = await response.json();
 
       // Transform the data into our PullRequest interface
-      return data.map((pr: any) => ({
+      return data.map((pr: GitHubPullRequest) => ({
         id: pr.id,
         number: pr.number,
         title: pr.title,

--- a/src/services/PullRequestService.ts
+++ b/src/services/PullRequestService.ts
@@ -26,6 +26,8 @@ interface GitHubPullRequest {
   draft: boolean;
   requested_reviewers: unknown[];
   reviews?: unknown[];
+  review_comments: number;
+  reviews_count: number;
 }
 
 export class PullRequestService {

--- a/src/services/PullRequestService.ts
+++ b/src/services/PullRequestService.ts
@@ -1,0 +1,88 @@
+/**
+ * PullRequestService.ts
+ * Service to monitor pull requests on GitHub repositories
+ */
+
+export interface PullRequest {
+  id: number;
+  number: number;
+  title: string;
+  url: string;
+  isDraft: boolean;
+  hasReviewers: boolean;
+  hasBeenReviewed: boolean;
+}
+
+export interface Repository {
+  owner: string;
+  name: string;
+}
+
+export class PullRequestService {
+  private baseUrl = 'https://api.github.com';
+  
+  /**
+   * Fetches pull requests from a GitHub repository
+   * @param repo Repository information (owner and name)
+   * @param token Optional GitHub token for authentication
+   * @returns Promise with array of pull requests
+   */
+  async fetchPullRequests(repo: Repository, token?: string): Promise<PullRequest[]> {
+    const url = `${this.baseUrl}/repos/${repo.owner}/${repo.name}/pulls?state=open`;
+    const headers: HeadersInit = {
+      'Accept': 'application/vnd.github.v3+json',
+    };
+    
+    if (token) {
+      headers['Authorization'] = `token ${token}`;
+    }
+    
+    try {
+      const response = await fetch(url, { headers });
+      
+      if (!response.ok) {
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+      }
+      
+      const data = await response.json();
+      
+      // Transform the data into our PullRequest interface
+      return data.map((pr: any) => ({
+        id: pr.id,
+        number: pr.number,
+        title: pr.title,
+        url: pr.html_url,
+        isDraft: pr.draft,
+        hasReviewers: pr.requested_reviewers?.length > 0,
+        hasBeenReviewed: pr.review_comments > 0 || pr.reviews_count > 0
+      }));
+    } catch (error) {
+      console.error('Error fetching pull requests:', error);
+      throw error;
+    }
+  }
+  
+  /**
+   * Gets pull requests that are open, not in draft status, but have no assigned reviewers
+   * @param repo Repository information
+   * @param token Optional GitHub token
+   * @returns Promise with filtered pull requests
+   */
+  async getPullRequestsWithNoReviewers(repo: Repository, token?: string): Promise<PullRequest[]> {
+    const pullRequests = await this.fetchPullRequests(repo, token);
+    return pullRequests.filter(pr => !pr.isDraft && !pr.hasReviewers);
+  }
+  
+  /**
+   * Gets pull requests that have been reviewed but are not in draft status
+   * @param repo Repository information
+   * @param token Optional GitHub token
+   * @returns Promise with filtered pull requests
+   */
+  async getReviewedNonDraftPullRequests(repo: Repository, token?: string): Promise<PullRequest[]> {
+    const pullRequests = await this.fetchPullRequests(repo, token);
+    return pullRequests.filter(pr => !pr.isDraft && pr.hasBeenReviewed);
+  }
+}
+
+export default PullRequestService;


### PR DESCRIPTION
This PR implements a pull request service that monitors two different types of pull requests on a specified GitHub repo:

1. Pull requests that are open, not in draft status, but have no assigned reviewers.
2. Pull requests that have been reviewed but are in non-draft status.

The implementation includes:
- A PullRequestService class that interacts with the GitHub API
- A PullRequestMonitor component to display the monitored pull requests
- Updated App component with a form to specify repository details
- Comprehensive tests for all new components and services

All tests are passing.

Fixes #2

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2fc163877f0e41e4a3ac1f2b282e077c)