### PR TITLE
Add repository instructions about linting

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,0 +1,38 @@
+# Repository Information
+
+This document provides essential information about the repo-monitor repository.
+
+## Building and Linting
+
+Before submitting a pull request, please ensure that your changes pass the building and linting checks. The repository uses a GitHub workflow for continuous integration that checks building, linting, and testing.
+
+To verify that your changes will pass these checks locally:
+
+1. **Install dependencies**:
+   ```bash
+   npm ci
+   ```
+
+2. **Build the project**:
+   ```bash
+   npm run build
+   ```
+
+3. **Run linting**:
+   ```bash
+   npm run lint
+   ```
+
+4. **Run tests**:
+   ```bash
+   npm run test:run
+   ```
+
+All of these checks must pass before your pull request can be merged. The GitHub workflow will automatically run these checks when you create or update a pull request.
+
+If you encounter any linting errors, you can fix many of them automatically by running:
+```bash
+npm run lint -- --fix
+```
+
+Please make sure all checks pass locally before submitting your pull request to avoid delays in the review process.


### PR DESCRIPTION
This PR adds instructions about linting to the `.openhands/microagents/repo.md` file as requested in issue #12.

The instructions include:
- How to run the build process locally
- How to run linting checks
- How to run tests
- How to automatically fix linting errors

Fixes #12

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e8023c37b14f4b8eb86ccce3bdc3d26f)