### PR TITLE
Update documentation to explain what repo-monitor does

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,43 @@
-# repo-monitor
+# GitHub Repository Monitor
 
-A modern JavaScript application built with Vite, TypeScript, and React.
+A web application for monitoring GitHub repository pull requests. Track open PRs that need reviewers and reviewed PRs that are ready for action.
+
+🌐 **Live Demo**: [repo-monitor.vercel.app](https://repo-monitor.vercel.app)
+
+## What it does
+
+This tool helps you monitor GitHub repositories by tracking:
+
+- **Open PRs with No Reviewers** - Pull requests that are open, not in draft status, but have no assigned reviewers
+- **Reviewed Non-Draft PRs** - Pull requests that have been reviewed and are ready for potential merge
+
+Simply enter any GitHub repository (owner/name) and optionally provide a GitHub token for private repositories or higher API rate limits.
 
 ## Features
 
-- ⚡️ **Vite** - Fast build tool and development server
-- ⚛️ **React 19** - Modern React with latest features
-- 🔷 **TypeScript** - Type-safe JavaScript
-- 🧪 **Vitest** - Fast unit testing framework
-- 🧹 **ESLint** - Code linting and formatting
-- 📦 **Modern tooling** - Latest development tools and best practices
+- 🔍 **Real-time PR monitoring** - Fetch and display current pull request status
+- 🔐 **GitHub token support** - Access private repositories and avoid rate limits
+- ⚡️ **Fast and responsive** - Built with modern React and TypeScript
+- 🎯 **Focused insights** - Shows only the PRs that need attention
 
-## Getting Started
+## How to Use
+
+1. **Visit the live application**: [repo-monitor.vercel.app](https://repo-monitor.vercel.app)
+2. **Enter repository details**: Input the GitHub repository owner and name (e.g., `facebook/react`)
+3. **Optional GitHub token**: Add your GitHub personal access token for:
+   - Access to private repositories
+   - Higher API rate limits (5000 requests/hour vs 60/hour)
+4. **Monitor PRs**: View categorized pull requests that need attention
+
+### GitHub Token Setup
+
+To create a GitHub personal access token:
+
+1. Go to GitHub Settings → Developer settings → Personal access tokens
+2. Generate a new token with `repo` scope for private repositories
+3. Copy and paste the token into the application
+
+## Development Setup
 
 ### Prerequisites
 
@@ -21,63 +47,27 @@ A modern JavaScript application built with Vite, TypeScript, and React.
 ### Installation
 
 1. Clone the repository:
+
 ```bash
 git clone https://github.com/neubig/repo-monitor.git
 cd repo-monitor
 ```
 
 2. Install dependencies:
+
 ```bash
 npm install
 ```
 
-### Development
+3. Start the development server:
 
-Start the development server:
 ```bash
 npm run dev
 ```
 
 The application will be available at `http://localhost:5173/`
 
-### Building
-
-Build the application for production:
-```bash
-npm run build
-```
-
-### Testing
-
-Run tests:
-```bash
-npm run test        # Run tests in watch mode
-npm run test:run    # Run tests once
-```
-
-### Linting
-
-Check code quality:
-```bash
-npm run lint
-```
-
-## Project Structure
-
-```
-src/
-├── App.tsx          # Main application component
-├── App.test.tsx     # Tests for App component
-├── main.tsx         # Application entry point
-├── index.css        # Global styles
-├── App.css          # Component styles
-├── vite-env.d.ts    # Vite type definitions
-├── assets/          # Static assets
-└── test/
-    └── setup.ts     # Test configuration
-```
-
-## Scripts
+### Available Scripts
 
 - `npm run dev` - Start development server
 - `npm run build` - Build for production
@@ -86,11 +76,29 @@ src/
 - `npm run test:run` - Run tests once
 - `npm run lint` - Run ESLint
 
+## Deployment
+
+The application is automatically deployed to Vercel at [repo-monitor.vercel.app](https://repo-monitor.vercel.app). Any changes pushed to the main branch will trigger a new deployment.
+
 ## Technologies Used
 
-- [Vite](https://vite.dev/) - Build tool
-- [React](https://react.dev/) - UI library
-- [TypeScript](https://www.typescriptlang.org/) - Type safety
-- [Vitest](https://vitest.dev/) - Testing framework
-- [Testing Library](https://testing-library.com/) - Testing utilities
-- [ESLint](https://eslint.org/) - Code linting
+- **Frontend**: React 19 with TypeScript
+- **Build Tool**: Vite
+- **Testing**: Vitest with Testing Library
+- **Deployment**: Vercel
+- **API**: GitHub REST API v3
+
+## Project Structure
+
+```
+src/
+├── components/
+│   ├── PullRequestMonitor.tsx    # Main PR monitoring component
+│   └── GithubTokenManager.tsx    # GitHub token management
+├── services/
+│   └── PullRequestService.ts     # GitHub API integration
+├── utils/
+│   └── github.ts                 # GitHub utility functions
+├── App.tsx                       # Main application component
+└── main.tsx                      # Application entry point
+```


### PR DESCRIPTION
This PR addresses issue #16 by creating concise documentation that explains:

## What this repo does
- GitHub Repository Monitor for tracking pull requests
- Shows open PRs with no reviewers assigned
- Shows reviewed non-draft PRs ready for action
- Supports any public GitHub repository + private repos with token

## How to use it and set it up
- Added step-by-step usage instructions
- Included GitHub token setup guide for private repos and higher rate limits
- Clear development setup instructions for contributors

## Where it is deployed
- Prominently featured the live demo link: [repo-monitor.vercel.app](https://repo-monitor.vercel.app)
- Added deployment section explaining Vercel auto-deployment

## Changes made
- Completely rewrote README.md to be user-focused rather than generic
- Added clear feature descriptions with emojis for better readability
- Reorganized content flow: What it does → How to use → Development setup
- Updated project structure to reflect actual components
- Added technologies used section with current stack

The documentation is now concise, informative, and directly addresses what users need to know to understand and use the application.

Fixes #16

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/142c59bd11694046acae3cdbfb47ba3a)