### PR TITLE
feat: store most recently accessed repository in local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,13 @@ import { useState, useEffect } from 'react';
 import openHandsLogo from './assets/all-hands-logo.svg';
 import './App.css';
 import { GithubTokenManager } from './components/GithubTokenManager';
-import { hasGithubToken, getGithubToken } from './utils/github';
+import {
+  hasGithubToken,
+  getGithubToken,
+  getLastRepository,
+  saveLastRepository,
+  repositoryToUrl,
+} from './utils/github';
 import PullRequestMonitor from './components/PullRequestMonitor';
 import type { Repository } from './services/PullRequestService';
 
@@ -16,6 +22,13 @@ function App() {
   useEffect(() => {
     // Check if token exists on initial load
     setHasToken(hasGithubToken());
+
+    // Load the last accessed repository if it exists
+    const lastRepo = getLastRepository();
+    if (lastRepo) {
+      const repoUrl = repositoryToUrl(lastRepo);
+      setRepoUrl(repoUrl);
+    }
   }, []);
 
   // Parse GitHub repository URL to extract owner and name
@@ -58,6 +71,8 @@ function App() {
       if (repo) {
         setRepository(repo);
         setIsMonitoring(true);
+        // Save the repository as the most recently accessed
+        saveLastRepository(repo);
       } else {
         setError('Invalid repository URL format. Please use format: https://github.com/owner/repo');
       }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -2,7 +2,10 @@
  * GitHub API utilities
  */
 
+import type { Repository } from '../services/PullRequestService';
+
 const GITHUB_TOKEN_KEY = 'github_token';
+const LAST_REPO_KEY = 'last_repository';
 
 /**
  * Get the GitHub token from local storage
@@ -52,4 +55,49 @@ export const fetchGithubApi = async <T>(url: string): Promise<T> => {
   }
 
   return response.json();
+};
+
+/**
+ * Get the last accessed repository from local storage
+ */
+export const getLastRepository = (): Repository | null => {
+  const repoData = localStorage.getItem(LAST_REPO_KEY);
+  if (!repoData) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(repoData) as Repository;
+  } catch (error) {
+    console.error('Error parsing stored repository data:', error);
+    return null;
+  }
+};
+
+/**
+ * Save the last accessed repository to local storage
+ */
+export const saveLastRepository = (repository: Repository): void => {
+  localStorage.setItem(LAST_REPO_KEY, JSON.stringify(repository));
+};
+
+/**
+ * Clear the last accessed repository from local storage
+ */
+export const clearLastRepository = (): void => {
+  localStorage.removeItem(LAST_REPO_KEY);
+};
+
+/**
+ * Check if a last accessed repository is stored
+ */
+export const hasLastRepository = (): boolean => {
+  return !!getLastRepository();
+};
+
+/**
+ * Convert a repository object to a GitHub URL string
+ */
+export const repositoryToUrl = (repository: Repository): string => {
+  return `https://github.com/${repository.owner}/${repository.name}`;
 };


### PR DESCRIPTION
This PR implements the feature requested in issue #18 to store the most recently accessed repository in local storage.

## Changes Made

### Core Functionality
- **Added repository storage functions** to `src/utils/github.ts`:
  - `getLastRepository()` - retrieves the last accessed repository from localStorage
  - `saveLastRepository(repository)` - saves a repository to localStorage
  - `clearLastRepository()` - removes the stored repository
  - `hasLastRepository()` - checks if a repository is stored
  - `repositoryToUrl(repository)` - converts repository object to GitHub URL

### App Integration
- **Modified `src/App.tsx`** to:
  - Load the last accessed repository on initial app load
  - Pre-populate the repository input field with the last accessed repository URL
  - Save the repository to localStorage when monitoring starts

### Testing
- **Added comprehensive tests** in `src/utils/github.test.ts` for all new repository storage functions
- **Extended `src/App.test.tsx`** with integration tests to verify:
  - Repository loading on app initialization
  - Input field pre-population
  - Repository saving when monitoring starts
  - Error handling for invalid URLs

## Implementation Details

The implementation follows the same pattern as the existing GitHub token storage:
- Uses localStorage for persistence
- Stores repository data as JSON
- Includes error handling for invalid JSON
- Maintains type safety with TypeScript

## Testing

All tests pass:
- ✅ 48 tests passing
- ✅ Linting checks pass
- ✅ Build succeeds
- ✅ Pre-commit hooks pass

## User Experience

Users will now experience:
1. **Automatic repository loading** - when they return to the site, their last accessed repository will be pre-loaded
2. **Seamless workflow** - no need to re-enter repository URLs for frequently monitored repos
3. **Consistent behavior** - follows the same pattern as the GitHub token storage

Fixes #18

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b3e1e43451b7423a9b6312627547aac6)